### PR TITLE
fix a bug when setting the runtime type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.1.2 (Unreleased)
+## 0.1.3 (Unreleased)
+
+## 0.1.2
+
+BUGS:
+- Fixed a bug where an incorrect runtime type would be set on Release Channel configuration
 
 ## 0.1.1
 


### PR DESCRIPTION
It was using the wrong key when selecting the runtime value. This also
makes it a hard error if a type cannot be found rather than setting
unknown to avoid future problems.
