### PR TITLE
allow an existing managed k8s runtime to be "imported"

### DIFF
--- a/internal/provider/defaults/defaults.go
+++ b/internal/provider/defaults/defaults.go
@@ -27,7 +27,9 @@ func (d envDefaultValue) MarkdownDescription(ctx context.Context) string {
 
 func (d envDefaultValue) DefaultString(ctx context.Context, req defaults.StringRequest, resp *defaults.StringResponse) {
 	value := os.Getenv(d.envName)
-	if value != "" {
+	if value == "" {
+		resp.PlanValue = types.StringNull()
+	} else {
 		resp.PlanValue = types.StringValue(value)
 	}
 }
@@ -80,6 +82,8 @@ func (d envDefaultPathListValue) MarkdownDescription(ctx context.Context) string
 func (d envDefaultPathListValue) DefaultList(ctx context.Context, req defaults.ListRequest, resp *defaults.ListResponse) {
 	value := os.Getenv(d.envName)
 	if value != "" {
+		resp.PlanValue = types.ListNull(types.StringType)
+	} else {
 		paths := filepath.SplitList(value)
 		attrPaths := make([]attr.Value, len(paths))
 		for i, path := range paths {
@@ -92,6 +96,7 @@ func (d envDefaultPathListValue) DefaultList(ctx context.Context, req defaults.L
 		}
 		resp.PlanValue = listValue
 	}
+
 }
 
 func EnvPathListValue(envName string) defaults.List {

--- a/internal/provider/managed_k8s_runtime_resource.go
+++ b/internal/provider/managed_k8s_runtime_resource.go
@@ -604,7 +604,7 @@ func (r *ManagedK8sRuntimeResource) createOrUpdate(ctx context.Context, diags di
 		},
 	}
 	_, err = clientSet.CoreV1().Namespaces().Create(ctx, namespaceSpec, metav1.CreateOptions{})
-	if err != nil {
+	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "Failed to create agent namespace")
 	}
 
@@ -616,7 +616,7 @@ func (r *ManagedK8sRuntimeResource) createOrUpdate(ctx context.Context, diags di
 		},
 	}
 	_, err = clientSet.CoreV1().ServiceAccounts(saSpec.Namespace).Create(ctx, saSpec, metav1.CreateOptions{})
-	if err != nil {
+	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "Failed to create agent service account")
 	}
 
@@ -640,7 +640,7 @@ func (r *ManagedK8sRuntimeResource) createOrUpdate(ctx context.Context, diags di
 	}
 
 	_, err = clientSet.RbacV1().ClusterRoleBindings().Create(ctx, roleBindingSpec, metav1.CreateOptions{})
-	if err != nil {
+	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "Failed to create agent cluster role binding")
 	}
 
@@ -709,12 +709,12 @@ func (r *ManagedK8sRuntimeResource) createOrUpdate(ctx context.Context, diags di
 
 	tflog.Info(ctx, fmt.Sprintf("Creating new deployment: %#v", deploymentSpec))
 	_, err = clientSet.AppsV1().Deployments(namespaceSpec.Name).Create(ctx, deploymentSpec, metav1.CreateOptions{})
-	if err != nil {
+	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "Failed to create agent deployment")
 	}
 
 	err = WaitForClusterWithTimeout(ctx, r.client, linkResp.ClusterId, planData.Name.ValueString(), planData.Timeout.ValueString())
-	if err != nil {
+	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "Runtime linking failed")
 	}
 


### PR DESCRIPTION
Don't make it an error to have an existing k8s deployment, just require
that the runtime id annotation matches the one the API returns.

Implementing an actual `terraform import` for `managed_k8s_runtime` is
not easy (maybe not possible?) becuase we'd need to be able to pass in
k8s auth information at import time
