### PR TITLE
match api optional arguments on release channel preconditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 0.1.11 (Unreleased)
+## 0.1.12 (Unreleased)
+
+## 0.1.11
+
+FIXES:
+  - To match API behavior, `prodvana_release_channel` `manual_approval_preconditions.name` is now optional
+  - To match API behavior, `prodvana_release_channel` `release_channel_stable_preconditions.duration` is now optional
 
 ## 0.1.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 FIXES:
   - To match API behavior, `prodvana_release_channel` `manual_approval_preconditions.name` is now optional
-  - To match API behavior, `prodvana_release_channel` `release_channel_stable_preconditions.duration` is now optional
+
+CHANGES:
+  - `prodvana_release_channel.release_channel_stable_preconditions.duration` has been removed
 
 ## 0.1.10
 

--- a/internal/provider/release_channel_data_source.go
+++ b/internal/provider/release_channel_data_source.go
@@ -242,10 +242,6 @@ func (d *ReleaseChannelDataSource) Schema(ctx context.Context, req datasource.Sc
 							Required:            true,
 							Validators:          validators.DefaultNameValidators(),
 						},
-						"duration": schema.StringAttribute{
-							MarkdownDescription: "duration to wait for the release channel to be stable. A valid Go duration string, e.g. `10m` or `1h`. Defaults to `10m`",
-							Required:            true,
-						},
 					},
 				},
 			},

--- a/internal/provider/release_channel_resource_test.go
+++ b/internal/provider/release_channel_resource_test.go
@@ -130,6 +130,8 @@ func TestAccReleaseChannelResourceWithStablePrecondition(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("prodvana_release_channel.test", "name", "test"),
 
+					resource.TestCheckResourceAttr("prodvana_release_channel.pre2", "manual_approval_preconditions.0.name", ""),
+
 					resource.TestCheckResourceAttr("prodvana_release_channel.test", "release_channel_stable_preconditions.0.release_channel", "pre"),
 					resource.TestCheckResourceAttr("prodvana_release_channel.test", "release_channel_stable_preconditions.1.release_channel", "pre2"),
 
@@ -149,6 +151,8 @@ func TestAccReleaseChannelResourceWithStablePrecondition(t *testing.T) {
 				Config: testAccReleaseChannelResourceWithPreconditions(appName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("prodvana_release_channel.test", "name", "test"),
+
+					resource.TestCheckResourceAttr("prodvana_release_channel.pre2", "manual_approval_preconditions.0.name", ""),
 
 					resource.TestCheckResourceAttr("prodvana_release_channel.test", "release_channel_stable_preconditions.0.release_channel", "pre"),
 					resource.TestCheckResourceAttr("prodvana_release_channel.test", "release_channel_stable_preconditions.1.release_channel", "pre2"),
@@ -376,6 +380,7 @@ resource "prodvana_release_channel" "pre2" {
 		runtime = "default"
 	},
   ]
+  manual_approval_preconditions = [{}]
 }
 
 resource "prodvana_release_channel" "test" {
@@ -389,11 +394,9 @@ resource "prodvana_release_channel" "test" {
   release_channel_stable_preconditions = [
 	{
 		  release_channel = prodvana_release_channel.pre.name
-		  duration = "2s"
 	},
 	{
 		  release_channel = prodvana_release_channel.pre2.name
-		  duration = "2s"
 	},
   ]
   manual_approval_preconditions = [


### PR DESCRIPTION
manual approval's name and rc stable's duration field where inadvertently made required instead of optional.
this fixes it.
